### PR TITLE
refactor: Shorten links to relative paths

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -5,7 +5,9 @@
   "name": "No-Gaps",
   "description": "There will be no gaps in the sides to have a sleek look for every layout",
   "version": "2.5.2",
-  "style":{"chrome": "https://raw.githubusercontent.com/Comp-Tech-Guy/No-Gaps/refs/heads/main/style.css"},
+  "style": {
+    "chrome": "style.css"
+  },
   "readme": "https://raw.githubusercontent.com/Comp-Tech-Guy/No-Gaps/refs/heads/main/README.md",
   "image": "https://github.com/Comp-Tech-Guy/No-Gaps/blob/main/images/CompactMode.png?raw=true",
   "tags":[


### PR DESCRIPTION
Sine v2.3 allows for CSS to be linked as relative paths instead of links, making everything shorter and cleaner. This pull request implements that.